### PR TITLE
add build dependency on libtry-tiny-perl

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Build-Depends:
  libtest-mockobject-perl,
  libtest-output-perl,
  libtest-warn-perl,
+ libtry-tiny-perl,
  python3,
 Standards-Version: 3.9.8
 


### PR DESCRIPTION
Trying to build the package results in a test failure:

```
 not ok 1 - use Vyatta::Interface;
#   Failed test 'use Vyatta::Interface;'
#   at ./interface.t line 43.
#     Tried to use 'Vyatta::Interface'.
#     Error:  Can't locate Try/Tiny.pm in @INC (you may need to install the Try::Tiny module) (@INC contains: /usr/src/packages/BUILD/lib /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.28.1 /usr/local/share/perl/5.28.1 /usr/lib/x86_64-linux-gnu/perl5/5.28 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.28 /usr/share/perl/5.28 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/src/packages/BUILD/lib/Vyatta/Interface.pm line 28.
# BEGIN failed--compilation aborted at /usr/src/packages/BUILD/lib/Vyatta/Interface.pm line 28.
# Compilation failed in require at ./interface.t line 43.
# BEGIN failed--compilation aborted at ./interface.t line 43.
 ok 2 - use Vyatta::Address;
 not ok 3 - use Vyatta::DistributedDataplane;
#   Failed test 'use Vyatta::DistributedDataplane;'
#   at ./interface.t line 45.
#     Tried to use 'Vyatta::DistributedDataplane'.
#     Error:  Attempt to reload Vyatta/Interface.pm aborted.
# Compilation failed in require at /usr/src/packages/BUILD/lib/Vyatta/DistributedDataplane.pm line 16.
# BEGIN failed--compilation aborted at /usr/src/packages/BUILD/lib/Vyatta/DistributedDataplane.pm line 16.
# Compilation failed in require at ./interface.t line 45.
# BEGIN failed--compilation aborted at ./interface.t line 45.
 Undefined subroutine &Vyatta::Interface::parse_netdev_file called at ./interface.t line 47.
 1..3
 # Looks like your test exited with 255 just after 3.
 FAIL interface.t (exit status: 255)
 ```